### PR TITLE
determine key codes for extended keys during startup

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -1078,8 +1078,8 @@ char callinput(void)
 
 	// Ctrl-<Page-Up>, increase cqdelay by 1/2 second.
 	// Alt-<Page-Up>, same for terminals that consume Ctrl-<Page-Up>.
-	if ((strcmp(keyname(x), "kPRV5") == 0)
-	    || (strcmp(keyname(x), "kPRV3") == 0)) {
+	if ((key_kPRV3 && x == key_kPRV3)
+	    || (key_kPRV5 && x == key_kPRV5)) {
 
 		if (cqdelay <= 60) {
 		    cqdelay++;
@@ -1095,8 +1095,8 @@ char callinput(void)
 
 	// Ctrl-<Page-Down>, decrease cqdelay by 1/2 Second.
 	// Alt-<Page-Down>, same for terminals that consume Ctrl-<Page-Down>.
-	if ((strcmp(keyname(x), "kNXT5") == 0)
-	    || (strcmp(keyname(x), "kNXT3") == 0)) {
+	if ((key_kNXT3 && x == key_kNXT3)
+	    || (key_kNXT5 && x == key_kNXT5)) {
 
 		if (cqdelay >= 4) {
 		    cqdelay--;

--- a/src/main.c
+++ b/src/main.c
@@ -587,6 +587,8 @@ void ui_init()
     cbreak();
 
     keypad(stdscr,TRUE);
+
+    lookup_keys();
 }
 
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -28,6 +28,11 @@
 
 extern int use_rxvt;
 
+int key_kNXT3 = 0;
+int key_kPRV3 = 0;
+int key_kNXT5 = 0;
+int key_kPRV5 = 0;
+
 pthread_mutex_t panel_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static int getkey(int wait);
@@ -50,6 +55,41 @@ int modify_attr( int attr ) {
 	attr |= A_BOLD;
 
     return attr;
+}
+
+
+/** lookup key code by capability name
+ *
+ * ncurses automatically maps extended capabilities (such as kNXT3 or similar)
+ * to keycodes. But there is no fixed ordering for that.
+ * So we look up the key code by its name on strtup and use that afterwards.
+ * \param capability  - capability name
+ * \return              keycode or 0 if no associated key found
+ */
+int lookup_key(char *capability) {
+    char *esc_sequence = NULL;
+    int keycode = 0;
+
+    if (*capability == '\0') {
+	return 0;
+    }
+
+    esc_sequence = tigetstr(capability);
+
+    if (esc_sequence == NULL || esc_sequence == (char *)-1) {
+	return 0;
+    }
+
+    keycode = key_defined(esc_sequence);
+
+    return keycode;
+}
+
+void lookup_keys() {
+    key_kNXT3 = lookup_key("kNXT3");
+    key_kPRV3 = lookup_key("kPRV3");
+    key_kNXT5 = lookup_key("kNXT5");
+    key_kPRV5 = lookup_key("kPRV5");
 }
 
 /** key_get  wait for next key from terminal

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -21,8 +21,15 @@
 #ifndef UI_UTILS_H
 #define UI_UTILS_H
 
+extern int key_kNXT3;
+extern int key_kPRV3;
+extern int key_kNXT5;
+extern int key_kPRV5;
+
 void refreshp();
 int modify_attr(int attr);
+int lookup_key(char *capability);
+void lookup_keys();
 
 /** convenience macro to name alt-keys */
 #define ALT(c) (c + 128)


### PR DESCRIPTION
The patch does a lookup of undetermined key code definitions for Ctrl/Alt-PgUp/PgDn during startup of tlf.
It should work on any terminal - tested here on xfce terminal, xterm and rxvt. At least one of Ctrl- or Alt- combinations works as expected on all three systems.